### PR TITLE
Remove deprecated `bottle :unneeded` declaration

### DIFF
--- a/Formula/adb-event-mirror.rb
+++ b/Formula/adb-event-mirror.rb
@@ -5,8 +5,6 @@ class AdbEventMirror < Formula
   version "1.0.0"
   sha256 "ed1e09ac335e73ed193febbfd7748dfbe234c3f02c8054983fa46df5b3589280"
 
-  bottle :unneeded
-
   depends_on "kotlin"
 
   def install

--- a/Formula/asciinema-vsync.rb
+++ b/Formula/asciinema-vsync.rb
@@ -5,8 +5,6 @@ class AsciinemaVsync < Formula
   version "1.0.0"
   sha256 "dce0570141755f17be1a73a6c7bd79d2deb2f63c96ce1be9a44af308ea0fa23f"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   def install

--- a/Formula/dependency-tree-diff.rb
+++ b/Formula/dependency-tree-diff.rb
@@ -5,8 +5,6 @@ class DependencyTreeDiff < Formula
   version "1.2.0"
   sha256 "5d383b4413864c2437818ccdd71b9995e9983482da33382aad6dd62885e90bbd"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   def install

--- a/Formula/dependency-watch.rb
+++ b/Formula/dependency-watch.rb
@@ -5,8 +5,6 @@ class DependencyWatch < Formula
   version "0.3.0"
   sha256 "be1c18e3ce775aaf28a3d6b4cc54fa41b173db20b14df6247e38aadeb8652b6d"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   def install

--- a/Formula/diffuse.rb
+++ b/Formula/diffuse.rb
@@ -5,8 +5,6 @@ class Diffuse < Formula
   version "0.1.0"
   sha256 "60d619373c46a5d06b8126c1d61e0adc18b72f2cbb9245ef920d3387e44b86cf"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   def install

--- a/Formula/dockerfile-shebang.rb
+++ b/Formula/dockerfile-shebang.rb
@@ -6,8 +6,6 @@ class DockerfileShebang < Formula
   sha256 "a50acd031bc3fd3c2fa7106b8128f91bf56221ffcf41dfbfed2e6ee282a0d043"
   head "https://github.com/JakeWharton/dockerfile-shebang.git"
 
-  bottle :unneeded
-
   def install
     bin.install "dockerfile-shebang" => "dockerfile-shebang"
   end

--- a/Formula/dodo.rb
+++ b/Formula/dodo.rb
@@ -5,8 +5,6 @@ class Dodo < Formula
   version "1.1.0"
   sha256 "1225b00fd272da865197a5170b5f166907074beeca5bdecbabf1bd78e98ca7a9"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   def install

--- a/Formula/plex-orphaned-files.rb
+++ b/Formula/plex-orphaned-files.rb
@@ -5,8 +5,6 @@ class PlexOrphanedFiles < Formula
   version "1.1.1"
   sha256 "909e5f59f2a4ae1aa284f6c29182f43ed1c42a30be89809652c2fd1604066f83"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   def install


### PR DESCRIPTION
I'm getting the following warning from Homebrew now:
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the jakewharton/repo tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/jakewharton/homebrew-repo/Formula/dependency-watch.rb:8
```
This seems to be a relevant issue:

https://github.com/Homebrew/homebrew-core/issues/75943

Seems like just removing the line is the fix, but not 100% sure.